### PR TITLE
feat: tmux setup + nvim IDE improvements

### DIFF
--- a/.config/fastfetch/config-compact.jsonc
+++ b/.config/fastfetch/config-compact.jsonc
@@ -1,13 +1,8 @@
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
  "logo": {
-  "source": "~/.config/fastfetch/fedora.png",
-  "type": "kitty-direct",
-  "height": 10,
-  "width": 20,
-  "padding": {
-    "top": 1
-    }
+  "source": "fedora",
+  "type": "small"
   },
     "display": {
         "separator": " -> "

--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -29,4 +29,7 @@ window_padding_width 4
 selection_foreground none
 selection_background none
 
+# Pass Super+Shift+S to Sway for screenshots
+map ctrl+shift+s discard_event
+
 # colors handled by warm-burgundy.conf theme

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,6 +1,8 @@
 vim.g.mapleader = " "
 vim.g.maplocalleader = " "
 
+require("core.plugins")
+
 vim.opt.number = true
 vim.opt.relativenumber = true
 vim.opt.tabstop = 2
@@ -26,14 +28,85 @@ vim.opt.ignorecase = true
 vim.opt.smartcase = true
 vim.opt.timeoutlen = 300
 
+-- Auto-reload files changed externally (by Claude/opencode)
+vim.opt.autoread = true
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold" }, {
+  command = "checktime",
+})
+
 vim.keymap.set("n", "<leader>q", "<cmd>q<CR>")
 vim.keymap.set("n", "<leader>w", "<cmd>w<CR>")
 vim.keymap.set("n", "<leader>bd", "<cmd>bd<CR>")
 vim.keymap.set("n", "<C-s>", "<cmd>w<CR>")
-vim.keymap.set("n", "jj", "<Esc>")
 vim.keymap.set("v", "J", ":m '>+1<CR>gv=gv")
 vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv")
 vim.keymap.set("n", "<C-d>", "<C-d>zz")
 vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
+
+-- Help cheat sheet
+vim.keymap.set("n", "<leader>?", function()
+  local lines = {
+    " NVIM CHEAT SHEET",
+    " ──────────────────────────────",
+    "",
+    " NAVIGATION",
+    "   h/j/k/l     Move left/down/up/right",
+    "   gg          Top of file",
+    "   G           Bottom of file",
+    "   Ctrl+d/u    Half page down/up",
+    "   w/b         Next/prev word",
+    "",
+    " FILES",
+    "   Space e      File explorer",
+    "   Space ff     Find file",
+    "   Space fg     Search text in files",
+    "   Space fb     Open buffers",
+    "",
+    " LSP (on a function/variable)",
+    "   gd           Go to definition",
+    "   gr           Find references",
+    "   K            Hover docs",
+    "   Space rn     Rename",
+    "   Space ca     Code action",
+    "   Space fm     Format",
+    "",
+    " EDITING",
+    "   i            Insert mode",
+    "   Esc          Normal mode",
+    "   dd           Delete line",
+    "   yy           Copy line",
+    "   p            Paste",
+    "   u            Undo",
+    "   Ctrl+r       Redo",
+    "   gcc          Toggle comment",
+    "",
+    " WINDOWS & PANES",
+    "   Ctrl+h/j/k/l  Move between splits/tmux",
+    "   Space q       Quit",
+    "   Space w       Save",
+    "   Ctrl+s        Save",
+    "",
+    " GIT (diffview)",
+    "   Space gd     Review changes",
+    "   Space gc     Close diff view",
+    "",
+    " Press q to close",
+  }
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+  local width = 48
+  local height = #lines
+  vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    col = math.floor((vim.o.columns - width) / 2),
+    row = math.floor((vim.o.lines - height) / 2),
+    style = "minimal",
+    border = "rounded",
+  })
+  vim.keymap.set("n", "q", "<cmd>close<CR>", { buffer = buf })
+end, { desc = "Cheat sheet" })

--- a/.config/nvim/lua/plugins/ai.lua
+++ b/.config/nvim/lua/plugins/ai.lua
@@ -1,0 +1,20 @@
+return {
+  -- Diff viewer: review changes made by Claude Code / opencode
+  {
+    "sindrets/diffview.nvim",
+    cmd = { "DiffviewOpen", "DiffviewFileHistory" },
+    keys = {
+      { "<leader>gd", "<cmd>DiffviewOpen<CR>", desc = "Review all changes" },
+      { "<leader>gc", "<cmd>DiffviewClose<CR>", desc = "Close diff view" },
+      { "<leader>gf", "<cmd>DiffviewFileHistory %<CR>", desc = "File history" },
+    },
+    opts = {
+      enhanced_diff_hl = true,
+      view = {
+        merge_tool = {
+          layout = "diff3_mixed",
+        },
+      },
+    },
+  },
+}

--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -1,18 +1,19 @@
 return {
   -- Theme
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "sainnhe/gruvbox-material",
     priority = 1000,
     config = function()
-      vim.cmd.colorscheme("catppuccin-mocha")
+      vim.g.gruvbox_material_background = "medium"
+      vim.g.gruvbox_material_foreground = "material"
+      vim.cmd.colorscheme("gruvbox-material")
     end,
   },
 
   -- Telescope
   {
     "nvim-telescope/telescope.nvim",
-    dependencies = { "nvim-lua/plenary.nvim", "nvim-telescope/telescope-fzf-native.nvim" },
+    dependencies = { "nvim-lua/plenary.nvim", { "nvim-telescope/telescope-fzf-native.nvim", build = "make" } },
     config = function()
       local telescope = require("telescope")
       telescope.setup({
@@ -37,26 +38,18 @@ return {
     "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
     config = function()
-      require("nvim-treesitter.configs").setup({
-        ensure_installed = { "javascript", "typescript", "python", "go", "rust", "lua", "bash", "json", "yaml", "markdown", "html", "css" },
-        auto_install = true,
-        highlight = { enable = true },
-        indent = { enable = true },
-      })
+      require("nvim-treesitter").setup()
+      vim.treesitter.language.register("bash", "sh")
     end,
   },
 
-  -- LSP
+  -- Completion
   {
-    "neovim/nvim-lspconfig",
+    "hrsh7th/nvim-cmp",
     dependencies = {
-      "williamboman/mason.nvim",
-      "williamboman/mason-lspconfig.nvim",
       "hrsh7th/cmp-nvim-lsp",
       "hrsh7th/cmp-buffer",
       "hrsh7th/cmp-path",
-      "hrsh7th/cmp-cmdline",
-      "hrsh7th/nvim-cmp",
       "L3MON4D3/LuaSnip",
       "saadparwaiz1/cmp_luasnip",
     },
@@ -83,45 +76,44 @@ return {
           { name = "path" },
         }),
       })
+    end,
+  },
 
-      local capabilities = require("cmp_nvim_lsp").default_capabilities()
-      local lspconfig = require("lspconfig")
-
+  -- LSP
+  {
+    "williamboman/mason.nvim",
+    config = function()
       require("mason").setup()
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    dependencies = { "williamboman/mason.nvim" },
+    config = function()
       require("mason-lspconfig").setup({
         ensure_installed = { "ts_ls", "pyright", "gopls", "rust_analyzer", "lua_ls", "bashls", "jsonls", "yamlls", "html", "cssls" },
       })
 
-      local on_attach = function(_, bufnr)
-        local nmap = function(keys, func, desc)
-          if desc then desc = "LSP: " .. desc end
-          vim.keymap.set("n", keys, func, { buffer = bufnr, desc = desc })
-        end
-        nmap("gd", vim.lsp.buf.definition, "Go to definition")
-        nmap("gr", vim.lsp.buf.references, "References")
-        nmap("K", vim.lsp.buf.hover, "Hover")
-        nmap("<leader>rn", vim.lsp.buf.rename, "Rename")
-        nmap("<leader>ca", vim.lsp.buf.code_action, "Code action")
-        nmap("<leader>fm", vim.lsp.buf.format, "Format")
-      end
-
+      local capabilities = require("cmp_nvim_lsp").default_capabilities()
       local servers = { "ts_ls", "pyright", "gopls", "lua_ls", "bashls", "jsonls", "yamlls", "html", "cssls" }
-      for _, lsp in ipairs(servers) do
-        lspconfig[lsp].setup({
-          on_attach = on_attach,
-          capabilities = capabilities,
-        })
+      for _, server in ipairs(servers) do
+        vim.lsp.config[server] = { capabilities = capabilities }
       end
-
-      lspconfig["rust_analyzer"].setup({
-        on_attach = on_attach,
+      vim.lsp.config["rust_analyzer"] = {
         capabilities = capabilities,
         settings = {
-          ["rust-analyzer"] = {
-            check = { command = "clippy" },
-          },
+          ["rust-analyzer"] = { check = { command = "clippy" } },
         },
-      })
+      }
+      vim.lsp.enable(servers)
+      vim.lsp.enable("rust_analyzer")
+
+      vim.keymap.set("n", "gd", vim.lsp.buf.definition, { desc = "LSP: Go to definition" })
+      vim.keymap.set("n", "gr", vim.lsp.buf.references, { desc = "LSP: References" })
+      vim.keymap.set("n", "K", vim.lsp.buf.hover, { desc = "LSP: Hover" })
+      vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, { desc = "LSP: Rename" })
+      vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, { desc = "LSP: Code action" })
+      vim.keymap.set("n", "<leader>fm", vim.lsp.buf.format, { desc = "LSP: Format" })
     end,
   },
 
@@ -153,7 +145,7 @@ return {
     dependencies = { "nvim-tree/nvim-web-devicons" },
     config = function()
       require("lualine").setup({
-        options = { theme = "catppuccin" },
+        options = { theme = "gruvbox-material" },
       })
     end,
   },

--- a/.config/nvim/lua/plugins/tmux.lua
+++ b/.config/nvim/lua/plugins/tmux.lua
@@ -1,0 +1,19 @@
+return {
+  -- Seamless navigation between tmux panes and nvim splits
+  {
+    "christoomey/vim-tmux-navigator",
+    lazy = false,
+    cmd = {
+      "TmuxNavigateLeft",
+      "TmuxNavigateDown",
+      "TmuxNavigateUp",
+      "TmuxNavigateRight",
+    },
+    keys = {
+      { "<C-h>", "<cmd>TmuxNavigateLeft<CR>" },
+      { "<C-j>", "<cmd>TmuxNavigateDown<CR>" },
+      { "<C-k>", "<cmd>TmuxNavigateUp<CR>" },
+      { "<C-l>", "<cmd>TmuxNavigateRight<CR>" },
+    },
+  },
+}

--- a/.config/sway/config
+++ b/.config/sway/config
@@ -3,7 +3,7 @@
 # File manager: thunar
 
 set $mod Mod1
-set $term kitty
+set $term kitty tmux -u
 set $files thunar
 
 # Export environment to systemd so portals (file picker, screenshots) work
@@ -13,7 +13,7 @@ exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSO
 # Idle config (no dpms off — causes crashes on Asahi/Apple Silicon)
 # 5min: lock, 10min: dim screen (not to 0 — causes white screen on Asahi)
 exec swayidle -w \
-    timeout 300 'swaylock -f' \
+    timeout 300 'pgrep -x "mpv|vlc" > /dev/null || swaylock -f' \
     timeout 600 'brightnessctl set 5%' \
     resume 'brightnessctl set 50%' \
     before-sleep 'swaylock -f'
@@ -30,7 +30,7 @@ exec_always sh -c 'pgrep -x waybar && pkill -SIGUSR2 waybar || waybar &'
 # Output config
 output * bg ~/.config/hypr/wallpaper_effects/.wallpaper_current fill
 output HDMI-A-1 scale 1.5
-output eDP-1 scale 2
+output eDP-1 scale 1.5
 
 # Input config
 input * {
@@ -83,6 +83,8 @@ bindsym $mod+Shift+L exec swaylock -f
 # Screenshot
 bindsym Print exec grim -g "$(slurp)" - | wl-copy
 bindsym $mod+Print exec grim - | wl-copy
+bindsym Ctrl+Shift+s exec grim -g "$(slurp)" - | wl-copy
+
 
 # Screen recording (toggle with keybind, saves to ~/Videos)
 bindsym $mod+Shift+R exec sh -c 'if pgrep -x wf-recorder; then pkill -INT wf-recorder && notify-send "Recording saved"; else mkdir -p ~/Videos && notify-send "Recording started" && wf-recorder -c libopenh264 -f ~/Videos/recording-$(date +%Y%m%d-%H%M%S).mp4; fi'

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -1,0 +1,47 @@
+# Start windows and panes at 1
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Mouse support
+set -g mouse on
+
+# True color and font support
+set -g default-terminal "xterm-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+set -g allow-passthrough on
+
+# Increase scrollback
+set -g history-limit 50000
+
+# Faster key repetition
+set -s escape-time 0
+
+# Plugins
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'    # Save/restore sessions (C-b C-s to save, C-b C-r to restore)
+set -g @plugin 'egel/tmux-gruvbox'
+
+# Gruvbox theme
+set -g @tmux-gruvbox 'dark'
+
+# Show current directory as window name
+setw -g automatic-rename on
+setw -g automatic-rename-format '#{b:pane_current_path}'
+
+# Cheat sheet popup (prefix + h)
+bind h display-popup -w 52 -h 27 -E "bash /home/antoine/.local/bin/tmux-cheatsheet"
+
+# Vim-tmux-navigator: seamless Ctrl+h/j/k/l between tmux and nvim
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h' 'select-pane -L'
+bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j' 'select-pane -D'
+bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k' 'select-pane -U'
+bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l' 'select-pane -R'
+
+# Pane borders
+set -g pane-active-border-style "fg=#D8A657"
+
+# Initialize TPM (keep at bottom)
+run '~/.tmux/plugins/tpm/tpm'

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -1,6 +1,9 @@
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 export ZSH="$HOME/.oh-my-zsh"
 
 ZSH_THEME="agnosterzak"
@@ -41,6 +44,8 @@ alias la='ls -a'
 alias lla='ls -la'
 alias lt='ls --tree'
 
+alias clauded='claude --dangerously-skip-permissions'
+
 # opencode
 export PATH=$HOME/.opencode/bin:$PATH
 export PATH="$HOME/.local/bin:$PATH"
@@ -48,3 +53,18 @@ export PATH="$HOME/.local/bin:$PATH"
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# bun completions
+[ -s "/home/antoine/.bun/_bun" ] && source "/home/antoine/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# pnpm
+export PNPM_HOME="/home/antoine/.local/share/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+# pnpm end

--- a/home/tmux-cheatsheet
+++ b/home/tmux-cheatsheet
@@ -1,0 +1,36 @@
+#!/bin/bash
+clear
+printf "\n"
+printf "  \033[1;33mTMUX CHEAT SHEET\033[0m\n"
+printf "  \033[2mPrefix = Ctrl-b (press, release, then key)\033[0m\n"
+printf "\n"
+printf "  \033[1;32mWINDOWS\033[0m\n"
+printf "    c         New window\n"
+printf "    n         Next window\n"
+printf "    p         Previous window\n"
+printf "    1-9       Go to window #\n"
+printf "    ,         Rename window\n"
+printf "    &         Kill window\n"
+printf "\n"
+printf "  \033[1;32mPANES\033[0m\n"
+printf '    "         Split horizontal\n'
+printf "    %%         Split vertical\n"
+printf "    arrow     Move between panes\n"
+printf "    z         Zoom/unzoom pane\n"
+printf "    x         Kill pane\n"
+printf "    \033[2m(drag border with mouse to resize)\033[0m\n"
+printf "\n"
+printf "  \033[1;32mSESSIONS\033[0m\n"
+printf "    d         Detach\n"
+printf "    s         List sessions\n"
+printf "\n"
+printf "  \033[1;32mOTHER\033[0m\n"
+printf "    [         Scroll mode (q to exit)\n"
+printf "    :         Command prompt\n"
+printf "    h         This cheat sheet\n"
+printf "\n"
+printf "  \033[2mPress q to close\033[0m"
+while true; do
+    read -rsn1 key
+    [ "$key" = "q" ] && exit 0
+done


### PR DESCRIPTION
## Summary
- Tmux config with gruvbox theme, mouse, TPM, resurrect plugin, cheatsheet popup
- Nvim: gruvbox-material theme, diffview.nvim, vim-tmux-navigator, auto-reload, cheat sheet
- Updated nvim LSP/treesitter to 0.11 API
- Sway launches kitty+tmux on Super+Enter, Ctrl+Shift+S screenshot passthrough
- Fastfetch ASCII logo for tmux compatibility

## Files changed
- `home/.tmux.conf` — new tmux config
- `home/tmux-cheatsheet` — popup cheatsheet script
- `.config/nvim/` — LSP fix, gruvbox theme, new plugins
- `.config/sway/config` — tmux launch, screenshot binding
- `.config/kitty/kitty.conf` — key passthrough
- `.config/fastfetch/config-compact.jsonc` — ASCII logo
- `home/.zshrc` — UTF-8 locale export

## Summary by Sourcery

Introduce a tmux-based terminal workflow and improve Neovim as an IDE with gruvbox theming, modern LSP setup, and better integration with tmux and external tools.

New Features:
- Add a tmux configuration with gruvbox theme, plugins, mouse support, and a popup cheat sheet.
- Add Neovim plugins for diff review and seamless navigation between tmux panes and Neovim splits.
- Add an in-editor Neovim cheat sheet popup for core navigation, LSP, Git, and window commands.

Enhancements:
- Switch Neovim and statusline theming to gruvbox-material for a consistent terminal IDE appearance.
- Update Neovim LSP and Treesitter configuration to the 0.11 API and enable global LSP keymaps and capabilities.
- Enable Neovim auto-reload for files changed externally to better support tools like Claude/opencode.
- Configure kitty to pass through the Ctrl+Shift+S shortcut so Sway can handle screenshots.
- Extend shell configuration with UTF-8 locale settings and additional tooling (Claude, bun, pnpm) in PATH.